### PR TITLE
Feature/vigo arkivering

### DIFF
--- a/archiveMethods/vigoDocuments.js
+++ b/archiveMethods/vigoDocuments.js
@@ -36,7 +36,7 @@ module.exports = async (config) => {
                     .then((arkiveringsresultat) => {
                         oppdaterVigoArkiveringsstatus(arkiveringsresultat, oppdaterStatus);
                     })
-                    .catch((error) => { 
+                    .catch((error) => {
                         twhError('   Unhandled error in archiveVigoDocument', error)
                     });
             } catch (err) {
@@ -49,18 +49,18 @@ module.exports = async (config) => {
 function oppdaterVigoArkiveringsstatus(arkiveringsresultat, oppdaterStatus) {
     for (const melding of arkiveringsresultat) { // TODO: hva synes vigo om å få mange requester på rappen
         const oppdaterStatusArgumenter = {
-            Fagsystemnavn: melding.melding, // TODO: Lagrer arkiv-referanse ved vellykket arkivering for å kunne se i vigo hvor i P360 meldingen er lagret, men hva med meldinger uten dokuemnt?
+            Fagsystemnavn: melding.melding,
             DokumentId: melding.vigoMelding.Dokumentelement.DokumentId, // dokumnetid vigo
             Fodselsnummer: melding.vigoMelding.Fodselsnummer,
             ArkiveringUtfort: melding.arkiveringUtfort
         }
-        oppdaterStatus(oppdaterStatusArgumenter, (err, result/*, envelop, soapHeader*/) => { 
-            if (err) { 
-                writeLog(`   Error update status for vigo docId ${oppdaterStatusArgumenter.DokumentId} p360 docId: ${oppdaterStatusArgumenter.Fagsystemnavn}.`);
-                throw Error(err); // TODO: twh?
+        oppdaterStatus(oppdaterStatusArgumenter, (err, result/*, envelop, soapHeader*/) => {
+            if (err) {
+                writeLog(`=${DokumentId}=\tError during status update. p360 ref: ${oppdaterStatusArgumenter.Fagsystemnavn}.`);
+                throw Error(err); // TODO: twh eller kast feil? Tell antall feil og avbryt? Avvent og prøv på nytt?
             }
-            const {ArkiveringUtfort, DokumentId, Fagsystemnavn} = result.LagreStatusArkiverteDataResponseElm;
-            writeLog(`  Archived Status set to ${ArkiveringUtfort} for vigo docId ${DokumentId} p360 docId: ${Fagsystemnavn}`);
+            const { ArkiveringUtfort, DokumentId, Fagsystemnavn } = result.LagreStatusArkiverteDataResponseElm;
+            writeLog(`=${DokumentId}=\tArchived Status set to ${ArkiveringUtfort} for p360: ${Fagsystemnavn}`);
         })
     }
 }

--- a/archiveMethods/vigoDocuments.js
+++ b/archiveMethods/vigoDocuments.js
@@ -30,7 +30,7 @@ module.exports = async (config) => {
             try {
                 const { err, result } = await hentData(hentDataArgumenter);
                 if (err) { throw Error(err) }
-                if (!result.HentDataForArkiveringResponseElm ||
+                if (!result || !result.HentDataForArkiveringResponseElm ||
                     result.HentDataForArkiveringResponseElm.Feilmelding.Feiltype === "INGEN DATA") {
                     break;
                 }
@@ -64,7 +64,7 @@ function oppdaterVigoArkiveringsstatus(arkiveringsresultat, oppdaterStatus) {
                 throw Error(err); // TODO: twh eller kast feil? Tell antall feil og avbryt? Avvent og prøv på nytt?
             }
             const { ArkiveringUtfort, DokumentId, Fagsystemnavn } = result.LagreStatusArkiverteDataResponseElm;
-            writeLog(`=${DokumentId}=\tArchived Status set to ${ArkiveringUtfort} for p360: ${Fagsystemnavn}`);
+            writeLog(`=${DokumentId}=\tArchived Status set to ${ArkiveringUtfort} in Vigo for p360 document ${Fagsystemnavn}`);
         })
     }
 }

--- a/archiveMethods/vigoDocuments.js
+++ b/archiveMethods/vigoDocuments.js
@@ -28,14 +28,14 @@ module.exports = async (config) => {
 
         while (lesVidere) {
             try {
-                const { errorResponse, resultResponse } = await hentData(hentDataArgumenter);
-                if (errorResponse) { throw Error(err) }
-                if (!resultResponse.HentDataForArkiveringResponseElm ||
-                    resultResponse.HentDataForArkiveringResponseElm.Feilmelding.Feiltype === "INGEN DATA") {
+                const { err, result } = await hentData(hentDataArgumenter);
+                if (err) { throw Error(err) }
+                if (!result.HentDataForArkiveringResponseElm ||
+                    result.HentDataForArkiveringResponseElm.Feilmelding.Feiltype === "INGEN DATA") {
                     break;
                 }
 
-                await archiveVigoDocument(resultResponse.HentDataForArkiveringResponseElm.Elevelement, config)
+                await archiveVigoDocument(result.HentDataForArkiveringResponseElm.Elevelement, config)
                     .then((arkiveringsresultat) => {
                         oppdaterVigoArkiveringsstatus(arkiveringsresultat, oppdaterStatus);
                     })

--- a/modules/archiveVigoDocument/archiveVigoDocument.js
+++ b/modules/archiveVigoDocument/archiveVigoDocument.js
@@ -83,7 +83,7 @@ module.exports = async (vigoData, config) => {
                 documentData.elevmappeCaseNumber = studentFolderRes.CaseNumber; // Found elevmappe for student
                 documentData.elevmappeAccessGroup = studentFolderRes.AccessGroup
                 documentData.elevmappeStatus = studentFolderRes.Status
-                writeLog(`=${vigoId}=\tFound elevmappe with case number: " ${studentFolderRes.CaseNumber}`);
+                writeLog(`=${vigoId}=\tFound elevmappe with case number: ${studentFolderRes.CaseNumber}`);
             }
         } catch (error) {
             // maybe implement retry function or something here
@@ -210,6 +210,6 @@ async function registrerFeilVedArkivering(arkiveringStatusData, arkiveringsresul
 
     arkiveringsresultat.push(arkiveringStatusData);
 
-    writeLog(`ERROR: =${arkiveringStatusData.vigoMelding.vigoId}= ${feilBeskrivelse} ${error}`);
+    writeLog(`ERROR: =${arkiveringStatusData.vigoMelding.vigoId}= ${feilBeskrivelse} ... ${error}`);
     twhError(feilBeskrivelse, error);
 }

--- a/modules/archiveVigoDocument/archiveVigoDocument.js
+++ b/modules/archiveVigoDocument/archiveVigoDocument.js
@@ -26,7 +26,7 @@ module.exports = async (vigoData, config) => {
 
     for (const vigoMelding of vigoData) {
         const vigoId = vigoMelding.Dokumentelement.DokumentId;
-        writeLog(`--- New message! vigo id: ${vigoId} - document type: ${vigoMelding.Dokumentelement.Dokumenttype} ---`);
+        writeLog(`--- New message!\tvigo id: =${vigoId}= - document type: ${vigoMelding.Dokumentelement.Dokumenttype} ---`);
 
         let createElevmappeBool = false; // For control of creating elevmappe
 
@@ -41,7 +41,7 @@ module.exports = async (vigoData, config) => {
             documentType: vigoMelding.Dokumentelement.Dokumenttype,
             documentDate: formaterDokumentDato(vigoMelding.Dokumentelement.Dokumentdato),
             schoolAccessGroup: config.P360_CASE_ACCESS_GROUP,
-            schoolOrgNr: "506" // Agder
+            schoolOrgNr: "506" // Agder FK recno
         };
 
         // TODO: Dersom adresse ikke er med i vigo-dokument, finn i vis
@@ -172,8 +172,8 @@ module.exports = async (vigoData, config) => {
                             .then(() => {
                                 writeLog(`=${vigoId}=\t${signOffData.Document} signed off`);
                             }).catch((error) => {
-                                writeLog(`=${vigoId}=\tError when signing of document: ${error}`);
-                                twhError(`Error when signing of document ${signOffData.DocumentNumber} `, error);
+                                writeLog(`ERROR: =${vigoId}=\tError when signing of for document ${archiveRes.DocumentNumber}: ${error}`);
+                                twhError(`Error when signing of document ${signOffData.DocumentNumber} creted for vigo document ${vigoId}.`, error);
                             });
                     }
                 }
@@ -210,6 +210,6 @@ async function registrerFeilVedArkivering(arkiveringStatusData, arkiveringsresul
 
     arkiveringsresultat.push(arkiveringStatusData);
 
-    writeLog(`${feilBeskrivelse} ${error}`);
+    writeLog(`ERROR: =${arkiveringStatusData.vigoMelding.vigoId}= ${feilBeskrivelse} ${error}`);
     twhError(feilBeskrivelse, error);
 }


### PR DESCRIPTION
Endringer i logging for sporbarhet. Vigo-id brukes for å knytte sammen et forløp. Dette for å kunne se hvilke log-meldinger som hører sammen, da avskriving og status-oppdatering i vigo gjøres asynkront.